### PR TITLE
Change file list default ordering to newest first

### DIFF
--- a/internal/cmd/file.go
+++ b/internal/cmd/file.go
@@ -117,7 +117,7 @@ func newFileListCmd(fileSvc service.FileService) *cobra.Command {
 		Short: "List files in project",
 		Long: `List files in the current Uploadcare project with pagination and filtering.
 
-Returns files sorted by --ordering (default: datetime_uploaded ascending).
+Returns files sorted by --ordering (default: datetime_uploaded descending).
 Prefix the ordering field with - for descending (e.g., -datetime_uploaded).
 
 By default returns one page of up to --limit files (default: 100).
@@ -210,7 +210,7 @@ original_file_url, metadata, appdata (with --include-appdata).`,
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&ordering, "ordering", "datetime_uploaded", "Sort order (prefix - for descending)")
+	f.StringVar(&ordering, "ordering", "-datetime_uploaded", "Sort order (prefix - for descending)")
 	f.IntVar(&limit, "limit", 100, "Number of files per page")
 	f.StringVar(&startingPoint, "starting-point", "", "Starting point (RFC3339 datetime)")
 	f.StringVar(&stored, "stored", "", "Filter by stored status (true/false)")

--- a/internal/cmd/file_test.go
+++ b/internal/cmd/file_test.go
@@ -425,6 +425,27 @@ func TestFileList_PageAll_Quiet(t *testing.T) {
 	}
 }
 
+func TestFileList_DefaultOrdering(t *testing.T) {
+	var capturedOpts service.FileListOptions
+
+	mock := &mockFileService{
+		listFunc: func(ctx context.Context, opts service.FileListOptions) (*service.FileListResult, error) {
+			capturedOpts = opts
+			return &service.FileListResult{}, nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	_, _, err := executeCommand(t, root, "file", "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedOpts.Ordering != "-datetime_uploaded" {
+		t.Errorf("default ordering = %q, want %q", capturedOpts.Ordering, "-datetime_uploaded")
+	}
+}
+
 func TestFileList_Options(t *testing.T) {
 	var capturedOpts service.FileListOptions
 


### PR DESCRIPTION
- Change `file list` default `--ordering` from `datetime_uploaded` (oldest first) to `-datetime_uploaded` (newest first) for a more practical default
- Add test for the default ordering value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `file list` command now displays results sorted by upload date in descending order by default, showing the most recently uploaded files first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->