### PR TITLE
Fix --include-appdata having no effect on table output

### DIFF
--- a/internal/cmd/file.go
+++ b/internal/cmd/file.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -92,7 +94,23 @@ original_file_url, metadata, appdata (with --include-appdata).`,
 				return formatter.Format(cmd.OutOrStdout(), file)
 			}
 
-			return formatter.Format(cmd.OutOrStdout(), fileInfoTable(file))
+			if err := formatter.Format(cmd.OutOrStdout(), fileInfoTable(file)); err != nil {
+				return err
+			}
+			if !opts.Quiet && len(file.AppData) > 0 {
+				w := cmd.OutOrStdout()
+				var buf bytes.Buffer
+				if err := json.Indent(&buf, file.AppData, "", "  "); err != nil {
+					if _, err := fmt.Fprintf(w, "\nAppData:\n%s\n", string(file.AppData)); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(w, "\nAppData:\n%s\n", buf.String()); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
 		},
 	}
 
@@ -183,7 +201,7 @@ original_file_url, metadata, appdata (with --include-appdata).`,
 			}
 
 			if pageAll {
-				return runFileListAll(cmd, svc, listOpts, opts)
+				return runFileListAll(cmd, svc, listOpts, opts, includeAppData)
 			}
 
 			result, err := svc.List(cmd.Context(), listOpts)
@@ -195,15 +213,24 @@ original_file_url, metadata, appdata (with --include-appdata).`,
 				return formatter.Format(cmd.OutOrStdout(), result.Files)
 			}
 
-			table := output.NewTableData("UUID", "SIZE", "FILENAME", "STORED", "UPLOADED")
+			var table *output.TableData
+			if includeAppData {
+				table = output.NewTableData("UUID", "SIZE", "FILENAME", "STORED", "UPLOADED", "APPDATA")
+			} else {
+				table = output.NewTableData("UUID", "SIZE", "FILENAME", "STORED", "UPLOADED")
+			}
 			for _, f := range result.Files {
-				table.AddRow(
+				row := []string{
 					f.UUID,
 					strconv.FormatInt(f.Size, 10),
 					f.Filename,
 					strconv.FormatBool(f.IsStored),
 					formatTime(f.DatetimeUploaded),
-				)
+				}
+				if includeAppData {
+					row = append(row, truncateAppData(f.AppData, 50))
+				}
+				table.AddRow(row...)
 			}
 			return formatter.Format(cmd.OutOrStdout(), table)
 		},
@@ -221,7 +248,7 @@ original_file_url, metadata, appdata (with --include-appdata).`,
 	return cmd
 }
 
-func runFileListAll(cmd *cobra.Command, svc service.FileService, listOpts service.FileListOptions, opts output.FormatOptions) error {
+func runFileListAll(cmd *cobra.Command, svc service.FileService, listOpts service.FileListOptions, opts output.FormatOptions, includeAppData bool) error {
 	if opts.Quiet {
 		return svc.Iterate(cmd.Context(), listOpts, func(f service.File) error {
 			return nil
@@ -232,6 +259,12 @@ func runFileListAll(cmd *cobra.Command, svc service.FileService, listOpts servic
 	return svc.Iterate(cmd.Context(), listOpts, func(f service.File) error {
 		if opts.JSON {
 			return output.NDJSONLine(w, &f, opts.Fields, opts.JQ)
+		}
+		if includeAppData {
+			_, err := fmt.Fprintf(w, "%s\t%d\t%s\t%v\t%s\t%s\n",
+				f.UUID, f.Size, f.Filename, f.IsStored, formatTime(f.DatetimeUploaded),
+				truncateAppData(f.AppData, 50))
+			return err
 		}
 		_, err := fmt.Fprintf(w, "%s\t%d\t%s\t%v\t%s\n",
 			f.UUID, f.Size, f.Filename, f.IsStored, formatTime(f.DatetimeUploaded))
@@ -257,6 +290,17 @@ func fileInfoTable(file *service.File) *output.TableData {
 	}
 	table.AddRow("URL:", file.OriginalFileURL)
 	return table
+}
+
+func truncateAppData(data json.RawMessage, maxLen int) string {
+	if len(data) == 0 {
+		return ""
+	}
+	s := string(data)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 func formatTime(t time.Time) string {

--- a/internal/cmd/file_test.go
+++ b/internal/cmd/file_test.go
@@ -463,3 +463,157 @@ func TestFileList_Options(t *testing.T) {
 		t.Error("include appdata should be true")
 	}
 }
+
+func testFileWithAppData() *service.File {
+	f := testFile()
+	f.AppData = json.RawMessage(`{"uc_clamav_virus_scan":{"data":{"infected":false},"version":"1.0.0"}}`)
+	return f
+}
+
+func TestFileInfo_TableWithAppData(t *testing.T) {
+	mock := &mockFileService{
+		infoFunc: func(ctx context.Context, uuid string, includeAppData bool) (*service.File, error) {
+			return testFileWithAppData(), nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "file", "info", "--include-appdata", "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "AppData:") {
+		t.Errorf("output should contain AppData section\ngot:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "uc_clamav_virus_scan") {
+		t.Errorf("output should contain appdata content\ngot:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"infected": false`) {
+		t.Errorf("appdata should be pretty-printed with indentation\ngot:\n%s", stdout)
+	}
+}
+
+func TestFileInfo_TableWithAppData_Quiet(t *testing.T) {
+	mock := &mockFileService{
+		infoFunc: func(ctx context.Context, uuid string, includeAppData bool) (*service.File, error) {
+			return testFileWithAppData(), nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "--quiet", "file", "info", "--include-appdata", "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(stdout, "AppData:") {
+		t.Errorf("--quiet should suppress AppData section\ngot:\n%s", stdout)
+	}
+}
+
+func TestFileInfo_TableWithoutAppData(t *testing.T) {
+	mock := &mockFileService{
+		infoFunc: func(ctx context.Context, uuid string, includeAppData bool) (*service.File, error) {
+			return testFile(), nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "file", "info", "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(stdout, "AppData:") {
+		t.Errorf("output should not contain AppData section when flag is not set\ngot:\n%s", stdout)
+	}
+}
+
+func TestFileList_TableWithAppData(t *testing.T) {
+	f := testFileWithAppData()
+	mock := &mockFileService{
+		listFunc: func(ctx context.Context, opts service.FileListOptions) (*service.FileListResult, error) {
+			return &service.FileListResult{
+				Files: []service.File{*f},
+				Total: 1,
+			}, nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "file", "list", "--include-appdata")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "APPDATA") {
+		t.Errorf("output should contain APPDATA header\ngot:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "uc_clamav_virus_scan") {
+		t.Errorf("output should contain appdata content\ngot:\n%s", stdout)
+	}
+}
+
+func TestFileList_TableWithoutAppData(t *testing.T) {
+	mock := &mockFileService{
+		listFunc: func(ctx context.Context, opts service.FileListOptions) (*service.FileListResult, error) {
+			return &service.FileListResult{
+				Files: []service.File{*testFile()},
+				Total: 1,
+			}, nil
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "file", "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(stdout, "APPDATA") {
+		t.Errorf("output should not contain APPDATA column when flag is not set\ngot:\n%s", stdout)
+	}
+}
+
+func TestFileList_PageAll_TableWithAppData(t *testing.T) {
+	f := testFileWithAppData()
+	mock := &mockFileService{
+		iterateFunc: func(ctx context.Context, opts service.FileListOptions, fn func(service.File) error) error {
+			return fn(*f)
+		},
+	}
+
+	root := newTestRoot(mock)
+	stdout, _, err := executeCommand(t, root, "file", "list", "--page-all", "--include-appdata")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "uc_clamav_virus_scan") {
+		t.Errorf("streaming output should contain appdata\ngot:\n%s", stdout)
+	}
+}
+
+func TestTruncateAppData(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   json.RawMessage
+		maxLen int
+		want   string
+	}{
+		{"empty", nil, 50, ""},
+		{"short", json.RawMessage(`{"ok":true}`), 50, `{"ok":true}`},
+		{"exact", json.RawMessage(`12345`), 5, `12345`},
+		{"over", json.RawMessage(`{"uc_clamav_virus_scan":{"data":{"infected":false}}}`), 20, `{"uc_clamav_virus_sc...`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateAppData(tt.data, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateAppData(%q, %d) = %q, want %q", string(tt.data), tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- `file info` table now renders a pretty-printed AppData JSON section below the main table when `--include-appdata` is set
- `file list` and `file list --page-all` table output now includes a truncated APPDATA column when `--include-appdata` is set
- Respects `--quiet` flag (no appdata output in quiet mode)
- Adds tests covering table rendering with/without appdata, quiet mode, and truncation edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show AppData in file info output (pretty-printed when available); omitted when quiet.
  * Optional APPDATA column in file list with truncated preview for long entries (enabled via flag).
  * Streaming/list-all output now includes AppData when enabled.

* **Tests**
  * Added comprehensive tests covering AppData display, truncation behavior, streaming output, and quiet-mode omission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->