### PR TITLE
Add UploadcareCLI/<version> to User-Agent header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/uploadcare/uploadcare-go/v2 v2.0.0
+	github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260409071548-d58ba67da138
 	go.yaml.in/yaml/v3 v3.0.4
 )
 
@@ -30,4 +30,4 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 )
 
-replace github.com/uploadcare/uploadcare-go/v2 => github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260326133346-236f3b01d0fb
+replace github.com/uploadcare/uploadcare-go/v2 => github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260409071548-d58ba67da138

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260326133346-236f3b01d0fb h1:3a/bBxrBduudEHlXezVvZIkEpc0xUdbqhIKOU3Ag2B0=
-github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260326133346-236f3b01d0fb/go.mod h1:nVtcYFEeUnxMjXbEsXzDefko4MdJpXjzBGRJtxwoCjU=
+github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260409071548-d58ba67da138 h1:Aoe226G5RvIEdIZkk1LbdIPZ09X62gDTq6bh4/zlSog=
+github.com/uploadcare/uploadcare-go/v2 v2.0.0-20260409071548-d58ba67da138/go.mod h1:nVtcYFEeUnxMjXbEsXzDefko4MdJpXjzBGRJtxwoCjU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/client/addon.go
+++ b/internal/client/addon.go
@@ -26,6 +26,7 @@ func NewAddonService(publicKey, secretKey string, httpClient *http.Client, verbo
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/convert.go
+++ b/internal/client/convert.go
@@ -27,6 +27,7 @@ func NewConvertService(publicKey, secretKey string, httpClient *http.Client, ver
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/file.go
+++ b/internal/client/file.go
@@ -35,6 +35,7 @@ func NewFileService(publicKey, secretKey, cdnBase string, httpClient *http.Clien
 		SignBasedAuthentication: true,
 		CDNBase:                cdnBase,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/group.go
+++ b/internal/client/group.go
@@ -28,6 +28,7 @@ func NewGroupService(publicKey, secretKey string, httpClient *http.Client, verbo
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/metadata.go
+++ b/internal/client/metadata.go
@@ -25,6 +25,7 @@ func NewMetadataService(publicKey, secretKey string, httpClient *http.Client, ve
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -25,6 +25,7 @@ func NewProjectService(publicKey, secretKey string, httpClient *http.Client, ver
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/client/project_management.go
+++ b/internal/client/project_management.go
@@ -19,6 +19,7 @@ type projectManagementService struct {
 func NewProjectManagementService(token string, httpClient *http.Client, verbose *output.VerboseLogger) (service.ProjectManagementService, error) {
 	conf := &ucare.Config{
 		HTTPClient: httpClient,
+		UserAgent:  UserAgent,
 	}
 	client, err := ucare.NewBearerClient(token, conf)
 	if err != nil {

--- a/internal/client/secret.go
+++ b/internal/client/secret.go
@@ -19,6 +19,7 @@ type secretService struct {
 func NewSecretService(token string, httpClient *http.Client, verbose *output.VerboseLogger) (service.SecretService, error) {
 	conf := &ucare.Config{
 		HTTPClient: httpClient,
+		UserAgent:  UserAgent,
 	}
 	client, err := ucare.NewBearerClient(token, conf)
 	if err != nil {

--- a/internal/client/usage.go
+++ b/internal/client/usage.go
@@ -21,6 +21,7 @@ type usageService struct {
 func NewUsageService(token string, httpClient *http.Client, verbose *output.VerboseLogger) (service.UsageService, error) {
 	conf := &ucare.Config{
 		HTTPClient: httpClient,
+		UserAgent:  UserAgent,
 	}
 	client, err := ucare.NewBearerClient(token, conf)
 	if err != nil {

--- a/internal/client/useragent.go
+++ b/internal/client/useragent.go
@@ -1,0 +1,5 @@
+package client
+
+// UserAgent is appended to the SDK's default User-Agent header.
+// Set this before creating any services (e.g. "UploadcareCLI/0.5.0").
+var UserAgent string

--- a/internal/client/useragent_test.go
+++ b/internal/client/useragent_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/uploadcare/uploadcare-cli/internal/service"
+)
+
+// headerCapturingTransport records request headers, keyed by host, from each request.
+type headerCapturingTransport struct {
+	mu      sync.Mutex
+	headers map[string]http.Header
+}
+
+func (t *headerCapturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	if t.headers == nil {
+		t.headers = make(map[string]http.Header)
+	}
+	if _, ok := t.headers[req.Host]; !ok {
+		t.headers[req.Host] = req.Header.Clone()
+	}
+	t.mu.Unlock()
+
+	return &http.Response{
+		StatusCode: 403,
+		Body:       io.NopCloser(strings.NewReader(`{"detail":"forbidden"}`)),
+		Header:     http.Header{"Content-Type": {"application/json"}},
+	}, nil
+}
+
+func (t *headerCapturingTransport) get(host string) http.Header {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.headers[host]
+}
+
+func (t *headerCapturingTransport) first() http.Header {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, h := range t.headers {
+		return h
+	}
+	return nil
+}
+
+func TestUserAgentHeader_RESTClient(t *testing.T) {
+	prev := UserAgent
+	UserAgent = "UploadcareCLI/1.2.3"
+	defer func() { UserAgent = prev }()
+
+	transport := &headerCapturingTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	svc, err := NewFileService("pub", "sec", "", httpClient, nil)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+
+	// The request will fail (403) but the transport captures the User-Agent header.
+	_, _ = svc.Info(context.Background(), "00000000-0000-0000-0000-000000000000", false)
+
+	ua := transport.get("api.uploadcare.com").Get("User-Agent")
+	if !strings.Contains(ua, "UploadcareCLI/1.2.3") {
+		t.Errorf("User-Agent = %q, want it to contain %q", ua, "UploadcareCLI/1.2.3")
+	}
+	if !strings.Contains(ua, "UploadcareGo/") {
+		t.Errorf("User-Agent = %q, want it to also contain SDK prefix", ua)
+	}
+}
+
+func TestUserAgentHeader_UploadClient(t *testing.T) {
+	prev := UserAgent
+	UserAgent = "UploadcareCLI/1.2.3"
+	defer func() { UserAgent = prev }()
+
+	transport := &headerCapturingTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	svc, err := NewFileService("pub", "sec", "", httpClient, nil)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+
+	// Upload triggers a request to upload.uploadcare.com.
+	_, _ = svc.Upload(context.Background(), service.UploadParams{
+		Data: strings.NewReader("test"),
+		Name: "test.txt",
+		Size: 4,
+	})
+
+	ua := transport.get("upload.uploadcare.com").Get("User-Agent")
+	if !strings.Contains(ua, "UploadcareCLI/1.2.3") {
+		t.Errorf("User-Agent = %q, want it to contain %q", ua, "UploadcareCLI/1.2.3")
+	}
+	if !strings.Contains(ua, "UploadcareGo/") {
+		t.Errorf("User-Agent = %q, want it to also contain SDK prefix", ua)
+	}
+}
+
+func TestUserAgentHeader_BearerClient(t *testing.T) {
+	prev := UserAgent
+	UserAgent = "UploadcareCLI/0.9.0"
+	defer func() { UserAgent = prev }()
+
+	transport := &headerCapturingTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	svc, err := NewProjectManagementService("test-token", httpClient, nil)
+	if err != nil {
+		t.Fatalf("NewProjectManagementService: %v", err)
+	}
+
+	_, _ = svc.List(context.Background(), service.ProjectListOptions{})
+
+	ua := transport.first().Get("User-Agent")
+	if !strings.Contains(ua, "UploadcareCLI/0.9.0") {
+		t.Errorf("User-Agent = %q, want it to contain %q", ua, "UploadcareCLI/0.9.0")
+	}
+}

--- a/internal/client/webhook.go
+++ b/internal/client/webhook.go
@@ -27,6 +27,7 @@ func NewWebhookService(publicKey, secretKey string, httpClient *http.Client, ver
 		APIVersion:             ucare.APIv07,
 		SignBasedAuthentication: true,
 		HTTPClient:             httpClient,
+		UserAgent:              UserAgent,
 	}
 	client, err := ucare.NewClient(creds, conf)
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/uploadcare/uploadcare-cli/internal/client"
 )
 
 // NewRootCmd creates the top-level "uploadcare" command with all global flags.
@@ -87,6 +88,8 @@ Use "uploadcare api-schema" for machine-readable command metadata.`,
 	flags.String("upload-api-base", "", "Override Upload API base URL (env: UPLOADCARE_UPLOAD_API_BASE)")
 	flags.String("cdn-base", "", "Override CDN base URL; auto-computed from public key when not set (env: UPLOADCARE_CDN_BASE)")
 	flags.String("project-api-base", "", "Override Project API base URL (env: UPLOADCARE_PROJECT_API_BASE)")
+
+	client.UserAgent = "UploadcareCLI/" + version
 
 	// Subcommands
 	rootCmd.AddCommand(newVersionCmd(version, commit, date))


### PR DESCRIPTION
- Set `ucare.Config.UserAgent` to `UploadcareCLI/<version>` in all SDK client constructors via a package-level `client.UserAgent` variable, set once in `NewRootCmd`
- Add tests covering all three API paths: REST (`api.uploadcare.com`), Upload (`upload.uploadcare.com`), and Project/Bearer API

Resulting User-Agent examples:

- REST API: `UploadcareGo/2.0.0/<pubkey> UploadcareCLI/0.5.0`
- Upload API: `UploadcareGo/2.0.0/<pubkey> UploadcareCLI/0.5.0`
- Project API: `UploadcareGo/2.0.0 UploadcareCLI/0.5.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom User-Agent support added so the CLI sets a consistent User-Agent that is included in all API client requests.

* **Tests**
  * Added tests verifying the User-Agent header is propagated across different client/service request paths.

* **Chores**
  * Bumped upstream SDK dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->