### PR TITLE
Support `uploadcare --version`

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,6 +43,12 @@ Use "uploadcare <command> --help" for details on any command.
 Use "uploadcare api-schema" for machine-readable command metadata.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if showVersion, _ := cmd.Flags().GetBool("version"); showVersion {
+				return printVersion(cmd, version, commit, date)
+			}
+			return cmd.Help()
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			f := cmd.Root().PersistentFlags()
 			verbose, _ := f.GetBool("verbose")
@@ -66,6 +72,9 @@ Use "uploadcare api-schema" for machine-readable command metadata.`,
 			return nil
 		},
 	}
+
+	// Local to root: `uploadcare --version`, mirroring the `version` subcommand.
+	rootCmd.Flags().Bool("version", false, "Print CLI version")
 
 	// Global flags
 	flags := rootCmd.PersistentFlags()

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -11,6 +11,7 @@ import (
 type apiSchema struct {
 	Version     string            `json:"version"`
 	GlobalFlags []flagSchema      `json:"global_flags"`
+	RootFlags   []flagSchema      `json:"root_flags,omitempty"`
 	Commands    []cmdSchema       `json:"commands"`
 	ExitCodes   map[string]string `json:"exit_codes"`
 	AgentNotes  []string          `json:"agent_notes"`
@@ -67,6 +68,7 @@ No authentication required.`,
 			schema := apiSchema{
 				Version:     version,
 				GlobalFlags: collectFlags(root.PersistentFlags()),
+				RootFlags:   rootOnlyFlags(root),
 				Commands:    collectCommands(root, ""),
 				ExitCodes: map[string]string{
 					"0": "Success",
@@ -75,6 +77,7 @@ No authentication required.`,
 					"3": "Auth/config error",
 				},
 				AgentNotes: []string{
+					"Flags under root_flags (e.g. --version) are accepted only on the bare 'uploadcare' command, not on subcommands — do not prepend them to subcommand invocations.",
 					"The --json flag requires a value: --json all (every field) or --json field1,field2 (specific fields).",
 					"The --jq flag implies --json. You do not need to pass both --json and --jq.",
 					"All timestamps are in RFC 3339 / UTC format.",
@@ -94,17 +97,36 @@ No authentication required.`,
 	}
 }
 
+// rootOnlyFlags returns flags accepted only on the bare "uploadcare" command
+// (currently --version). Unlike global flags, these are NOT inherited by
+// subcommands, so consumers must not prepend them to subcommand invocations.
+// The auto-generated --help flag is omitted.
+func rootOnlyFlags(root *cobra.Command) []flagSchema {
+	var flags []flagSchema
+	root.LocalNonPersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" {
+			return
+		}
+		flags = append(flags, flagToSchema(f))
+	})
+	return flags
+}
+
 func collectFlags(fs *pflag.FlagSet) []flagSchema {
 	var flags []flagSchema
 	fs.VisitAll(func(f *pflag.Flag) {
-		flags = append(flags, flagSchema{
-			Name:        f.Name,
-			Type:        f.Value.Type(),
-			Default:     f.DefValue,
-			Description: f.Usage,
-		})
+		flags = append(flags, flagToSchema(f))
 	})
 	return flags
+}
+
+func flagToSchema(f *pflag.Flag) flagSchema {
+	return flagSchema{
+		Name:        f.Name,
+		Type:        f.Value.Type(),
+		Default:     f.DefValue,
+		Description: f.Usage,
+	}
 }
 
 func collectCommands(cmd *cobra.Command, prefix string) []cmdSchema {

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -42,6 +42,55 @@ func TestAPISchema_ContainsAgentNotes(t *testing.T) {
 	}
 }
 
+func TestAPISchema_RootFlagsIncludeVersion(t *testing.T) {
+	root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"api-schema"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var schema struct {
+		GlobalFlags []struct {
+			Name string `json:"name"`
+		} `json:"global_flags"`
+		RootFlags []struct {
+			Name string `json:"name"`
+		} `json:"root_flags"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &schema); err != nil {
+		t.Fatalf("failed to parse schema JSON: %v", err)
+	}
+
+	// --version is root-only: it must NOT appear in global_flags (which are
+	// inherited by every command), only in root_flags.
+	for _, f := range schema.GlobalFlags {
+		if f.Name == "version" {
+			t.Error("global_flags must not include the root-only --version flag")
+		}
+	}
+
+	var hasVersion, hasHelp bool
+	for _, f := range schema.RootFlags {
+		switch f.Name {
+		case "version":
+			hasVersion = true
+		case "help":
+			hasHelp = true
+		}
+	}
+	if !hasVersion {
+		t.Error("root_flags should include the --version flag")
+	}
+	if hasHelp {
+		t.Error("root_flags should not include the auto-generated --help flag")
+	}
+}
+
 func TestAPISchema_CommandsHaveJSONFields(t *testing.T) {
 	root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -21,28 +21,35 @@ Use --json all for machine-readable output.`,
   # Print version as JSON
   uploadcare version --json all`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			opts := formatOptionsFromCmd(cmd)
-
-			if opts.JSON || opts.JQ != "" {
-				formatter := output.New(opts)
-				_ = formatter.Format(cmd.OutOrStdout(), map[string]string{
-					"version": version,
-					"commit":  commit,
-					"date":    date,
-					"go":      runtime.Version(),
-					"os":      runtime.GOOS,
-					"arch":    runtime.GOARCH,
-				})
-				return
-			}
-
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-				"uploadcare-cli %s\ncommit: %s\nbuilt:  %s\ngo:     %s\nos/arch: %s/%s\n",
-				version, commit, date,
-				runtime.Version(),
-				runtime.GOOS, runtime.GOARCH,
-			)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printVersion(cmd, version, commit, date)
 		},
 	}
+}
+
+func printVersion(cmd *cobra.Command, version, commit, date string) error {
+	opts := formatOptionsFromCmd(cmd)
+	if opts.Quiet {
+		return nil
+	}
+
+	if opts.JSON || opts.JQ != "" {
+		formatter := output.New(opts)
+		return formatter.Format(cmd.OutOrStdout(), map[string]string{
+			"version":    version,
+			"commit":     commit,
+			"date":       date,
+			"go_version": runtime.Version(),
+			"os":         runtime.GOOS,
+			"arch":       runtime.GOARCH,
+		})
+	}
+
+	_, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"uploadcare-cli %s\ncommit: %s\nbuilt:  %s\ngo:     %s\nos/arch: %s/%s\n",
+		version, commit, date,
+		runtime.Version(),
+		runtime.GOOS, runtime.GOARCH,
+	)
+	return err
 }

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -36,6 +36,98 @@ func TestVersionCmd(t *testing.T) {
 	}
 }
 
+func TestRootVersionFlag(t *testing.T) {
+	root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"--version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := []string{
+		"uploadcare-cli v0.1.0",
+		"commit: abc1234",
+		"built:  2026-03-08",
+		"go:     go",
+		"os/arch:",
+	}
+
+	for _, s := range expected {
+		if !strings.Contains(out, s) {
+			t.Errorf("output missing %q\ngot:\n%s", s, out)
+		}
+	}
+}
+
+func TestRootVersionFlag_JSONAll(t *testing.T) {
+	root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"--version", "--json", "all"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot:\n%s", err, buf.String())
+	}
+	if got["version"] != "v0.1.0" {
+		t.Errorf("version = %q, want %q", got["version"], "v0.1.0")
+	}
+}
+
+func TestVersionQuiet(t *testing.T) {
+	for _, args := range [][]string{
+		{"version", "--quiet"},
+		{"--version", "--quiet"},
+		{"version", "--quiet", "--json", "all"},
+	} {
+		root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
+		buf := new(bytes.Buffer)
+		root.SetOut(buf)
+		root.SetErr(new(bytes.Buffer))
+		root.SetArgs(args)
+
+		if err := root.Execute(); err != nil {
+			t.Fatalf("args %v: unexpected error: %v", args, err)
+		}
+		if out := buf.String(); out != "" {
+			t.Errorf("args %v: --quiet should suppress output, got:\n%s", args, out)
+		}
+	}
+}
+
+func TestVersionInvalidJQPropagatesError(t *testing.T) {
+	for _, args := range [][]string{
+		{"version", "--jq", "["},
+		{"--version", "--jq", "["},
+	} {
+		root := NewRootCmd("v0.1.0", "abc1234", "2026-03-08")
+		root.SetOut(new(bytes.Buffer))
+		root.SetErr(new(bytes.Buffer))
+		root.SetArgs(args)
+
+		err := root.Execute()
+		if err == nil {
+			t.Errorf("args %v: invalid jq should return an error", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "jq") {
+			t.Errorf("args %v: error should mention jq, got: %v", args, err)
+		}
+	}
+}
+
 func TestRootCmd_JSONFlagAll(t *testing.T) {
 	root := NewRootCmd("dev", "none", "unknown")
 	root.SetOut(new(bytes.Buffer))


### PR DESCRIPTION
Adds a root `--version` flag so both `uploadcare version` and `uploadcare --version` work. The flag is a true alias for the subcommand — they share one code path and produce byte-identical output, including `--json`/`--jq` support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Root command gains a local --version flag to print the CLI version (e.g., uploadcare --version).

* **API / Schema**
  * API schema now exposes root-only flags separately (e.g., --version) and documents they apply only to the bare CLI invocation.

* **Behavior Changes**
  * Version output supports JSON/JQ and quiet mode; structured JSON field renamed for Go runtime info.

* **Tests**
  * Added tests covering root --version behavior, JSON/JQ output, quiet suppression, and error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uploadcare/uploadcare-cli/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->